### PR TITLE
Improve tests helpers parsing

### DIFF
--- a/app/services/graphql_utils.rb
+++ b/app/services/graphql_utils.rb
@@ -1,0 +1,26 @@
+module GraphqlUtils
+  class ParseErrorBetterPrinted < ::GraphQL::ParseError
+    def initialize(exc)
+      super(exc.message, exc.line, exc.col, exc.query)
+    end
+
+    def to_s
+      "#{super}\n\n#{query}"
+    end
+  end
+
+  def self.hash_to_gql(attributes)
+    attr_gql_lines = attributes.map do |key, value|
+      new_key = key.to_s.camelize(:lower)
+      "#{new_key}: #{value.inspect || '""'}"
+    end
+
+    " { #{attr_gql_lines.join(', ')} } "
+  end
+
+  def self.validate!(some_string)
+    GraphQL.parse(some_string)
+  rescue ::GraphQL::ParseError => e
+    raise ParseErrorBetterPrinted, e
+  end
+end

--- a/spec/requests/users/create_spec.rb
+++ b/spec/requests/users/create_spec.rb
@@ -11,14 +11,12 @@ describe 'Create user mutation request', type: :request do
   let(:password) { 'abcd1234' }
 
   let(:attributes) do
-    <<~GQL
-      {
-         firstName: "#{first_name}",
-         lastName: "#{last_name}",
-         email: "#{email}",
-         password: "#{password}"
-       }
-    GQL
+    {
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      password: password
+    }
   end
 
   let(:return_types) do
@@ -73,19 +71,19 @@ describe 'Create user mutation request', type: :request do
       request
 
       token = response_content[:token]
-      expect(token).to be
+      expect(token).to_not be_nil
       expect(AuthToken.verify(token)).to eq(created_user)
     end
   end
 
   context 'with invalid params' do
     context 'when the email is missing' do
-      let(:email) { nil }
+      let(:email) { '' }
 
       it 'returns an error message' do
         request
 
-        expect(first_error_message).to include("can't be blank")
+        expect(first_error_message).to_not be_nil
       end
 
       it 'does not create a user' do
@@ -96,12 +94,12 @@ describe 'Create user mutation request', type: :request do
     end
 
     context 'when the password is missing' do
-      let(:password) { nil }
+      let(:password) { '' }
 
       it 'returns an error message' do
         request
 
-        expect(first_error_message).to include("can't be blank")
+        expect(first_error_message).to_not be_nil
       end
 
       it 'does not create a user' do

--- a/spec/requests/users/sign_in_spec.rb
+++ b/spec/requests/users/sign_in_spec.rb
@@ -11,12 +11,10 @@ describe 'Sign in user mutation request', type: :request do
   let(:password) { 'abcd1234' }
 
   let(:attributes) do
-    <<~GQL
-      {
-        email: "#{email_param}",
-        password: "#{password_param}"
-      }
-    GQL
+    {
+      email: email_param,
+      password: password_param
+    }
   end
 
   let(:email_param) { email }
@@ -36,9 +34,9 @@ describe 'Sign in user mutation request', type: :request do
     GQL
   end
 
-  context 'with valid params' do
-    let(:response_content) { json[:data][:signInUser] }
+  let(:response_content) { json[:data][:signInUser] }
 
+  context 'with valid params' do
     specify do
       request
 
@@ -87,23 +85,23 @@ describe 'Sign in user mutation request', type: :request do
         expect(first_error).to eq(I18n.t('errors.invalid_credentials'))
       end
 
-      it 'does not create a user' do
-        expect {
-          request
-        }.to_not change(User, :count)
+      it 'does not return the user sign in info' do
+        request
+
+        expect(response_content).to be_nil
       end
 
       it { is_expected.to render_error_code(:bad_request) }
     end
 
     context 'when the email is missing' do
-      let(:email_param) { nil }
+      let(:email_param) { '' }
 
       it_behaves_like 'does not sign in'
     end
 
     context 'when the password is missing' do
-      let(:password_param) { nil }
+      let(:password_param) { '' }
 
       it_behaves_like 'does not sign in'
     end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -14,23 +14,22 @@ module RequestHelpers
   end
 
   def mutation_path(name, attributes:, return_types:, headers: nil)
-    mutation_params = {
-      query:
-        <<~GQL
-            mutation {
-            #{name}(
-              input: { attributes: #{attributes} })
-              #{return_types}
-          }
-        GQL
-    }
+    attributes = GraphqlUtils.hash_to_gql(attributes) if attributes.is_a?(Hash)
 
-    # TODO. GraphQL.parse(params) so an error is raised if the body is malformed
+    query = <<~GQL
+        mutation {
+        #{name}(
+          input: { attributes: #{attributes} })
+          #{return_types}
+      }
+    GQL
 
-    graphql_request(params: mutation_params, headers: headers)
+    GraphqlUtils.validate!(query.to_s)
+
+    graphql_request(params: { query: query }, headers: headers)
   end
 
   def graphql_request(params:, headers: nil)
-    post graphql_path, params: params, headers: headers
+    post(graphql_path, params: params, headers: headers)
   end
 end


### PR DESCRIPTION
#### Description:

**It allows us to define the mutation arguments in a hash-like syntax.** 

**It also raises an easy-to-debug error on tests if the body of the graphql is malformed** (validates the params before doing the request). 

---


#### :heavy_check_mark:Tasks:

* Makes the rspec request helper method parse the argument `attributes` into a graphql string if it is a Hash
* Creates GraphqlUtils class to do conversions from hashes (and in the future arrays) to graphql strings
* Creates an exception class that inherits from GraphQLParsing error, but overrides `to_s` method so that it prints out the body so that in the tests, when the graphql is malformed it prints it out for you so you can debug it super fast. 

Failing tests due to malformed query body would be printed out like this:

<img width="957" alt="Screen Shot 2020-04-30 at 11 51 25" src="https://user-images.githubusercontent.com/17788257/80726805-45b23800-8adb-11ea-97fe-d4962896fac9.png">


---

@loopstudio/ruby-devs
