### PR TITLE
Create helper method for auth headers

### DIFF
--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,4 +1,8 @@
 module RequestHelpers
+  def auth_headers(some_user = user)
+    { 'Authorization' => AuthToken.token(some_user) }
+  end
+
   def errors
     json[:errors]
   end


### PR DESCRIPTION
#### Description:

This adds the helper method `auth_helpers` to use in rspec of requests. 

For example, imagine you had to do a mutation that required authentication, you can now do:

```  
subject(:request) do
  mutation_path(:updateUser, attributes: attributes, return_types: return_types, headers: auth_headers)
  end

let(:user) { create(:user) }
```

If you don't pass an argument, it will use `user`. But if you want to you can pass the user explicitely