### PR TITLE
Changed users index to be a show current user profile

### DIFF
--- a/app/graphql/types/queries/user_queries.rb
+++ b/app/graphql/types/queries/user_queries.rb
@@ -4,20 +4,12 @@ module Types
       extend ActiveSupport::Concern
 
       included do
-        field :users, [Types::CustomTypes::UserType], null: false
-        field :user, Types::CustomTypes::UserType, null: false do
-          argument :id, GraphQL::Types::ID, required: true
-        end
+        field :user, Types::CustomTypes::UserType, null: false
       end
 
       # :reek:UtilityFunction
-      def users
-        User.order(:id)
-      end
-
-      # :reek:UtilityFunction
-      def user(id:)
-        Loaders::RecordLoader.for(User).load(id)
+      def user
+        context[:current_user]
       end
     end
   end

--- a/spec/requests/users/show_spec.rb
+++ b/spec/requests/users/show_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe 'Show current user request', type: :request do
+  let!(:user) { create(:user) }
+
+  let(:return_types) do
+    <<~GQL
+      user {
+        id
+        firstName
+        lastName
+        email
+      }
+    GQL
+  end
+
+  context 'when the user is logged in' do
+    subject(:request) do
+      query_path(return_types: return_types, headers: auth_headers)
+    end
+
+    specify do
+      request
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    specify do
+      request
+
+      expect(errors).to be_nil
+    end
+
+    it 'returns the current user info' do
+      request
+
+      expect(json[:data][:user]).to include_json(
+        id: user.id.to_s,
+        firstName: user.first_name,
+        lastName: user.last_name,
+        email: user.email
+      )
+    end
+  end
+
+  context 'when the user is not logged in' do
+    subject(:request) do
+      query_path(return_types: return_types)
+    end
+
+    it 'returns an error message' do
+      request
+
+      expect(errors).not_to be_nil
+    end
+
+    it 'does not return any data' do
+      request
+
+      expect(json[:data]).to be_nil
+    end
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -33,6 +33,18 @@ module RequestHelpers
     graphql_request(params: { query: query }, headers: headers)
   end
 
+  def query_path(return_types:, headers: nil)
+    query = <<~GQL
+      {
+        #{return_types}
+      }
+    GQL
+
+    GraphqlUtils.validate!(query.to_s)
+
+    graphql_request(params: { query: query }, headers: headers)
+  end
+
   def graphql_request(params:, headers: nil)
     post(graphql_path, params: params, headers: headers)
   end


### PR DESCRIPTION
#### Description:

Users index changed to just show the current user profile + tests for said query.

**user_queries.rb** modified:
1.  _'users'_ method removed.
2. _'user'_ method modified, the parameter was removed, now it just returns the current_user data.
3. Only one field left (for the user method).

Added **query_path** method to the **request_helpers** to test this query, it requires a name (the type) and the return types (the attributes you want to request).

**To discuss:**
We currently do not have an **authentication enforcement** for the endpoints similar to the `before_action :authenticate_api_user` when using **devise_token_auth**. 

As a result when you query 'user' without being logged in it will return nil + an error message. 
I added the context  _'when the user is not logged in'_ to the tests anyway and just make sure **errors** is not _nil_ and that no **data** is being returned

---

#### :heavy_check_mark:Tasks:

* **user_queries.rb** modified to just show current_user profile info.
* Added test **users/show_spec** for said query
* Added a query_path method to **request_helpers.rb**

---

@loopstudio/ruby-devs
