### PR TITLE
Continuous deployment to Heroku with Github actions

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,5 @@
+MOUNT_GRAPHIQL=true
+
 # Local
 DB_HOST=localhost
 DB_USERNAME=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.0.4
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: ${{secrets.HEROKU_PROD_APP}}
+          heroku_email: ${{secrets.HEROKU_EMAIL}}

--- a/.release_tasks.sh
+++ b/.release_tasks.sh
@@ -1,0 +1,13 @@
+echo "Running Release Tasks"
+
+if [ "$MIGRATIONS_ON_RELEASE" == "true" ]; then
+  echo "Running Migrations"
+  bundle exec rails db:migrate
+fi
+
+if [ "$SEED_ON_RELEASE" == "true" ]; then
+  echo "Seeding DB"
+  bundle exec rails db:seed
+fi
+
+echo "Done running release_tasks.sh"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Metrics/AbcSize:
   Max: 15
   Exclude:
     - db/migrate/*
+    - app/channels/graphql_channel.rb
 
 Metrics/BlockLength:
   CountComments: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'rack-cors', '~> 1.1.1'
 gem 'rails', '~> 6.0.3'
 gem 'redis', '~> 4.1.4'
 gem 'sentry-raven', '~> 3.0.0'
+gem 'graphiql-rails', '~> 1.7.0'
 
 group :development, :test do
   gem 'bullet', '~> 6.1.0'
@@ -19,7 +20,6 @@ group :development, :test do
   gem 'dotenv-rails', '~> 2.7.5'
   gem 'factory_bot_rails', '~> 5.2.0'
   gem 'faker', '~> 2.11.0'
-  gem 'graphiql-rails', '~> 1.7.0'
   gem 'rspec-rails', '~> 4.0.1'
 end
 

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+worker: bundle exec sidekiq -C ./config/sidekiq.yml -v
+release: bash ./release_tasks.sh

--- a/app/channels/graphql_channel.rb
+++ b/app/channels/graphql_channel.rb
@@ -1,5 +1,7 @@
 class GraphqlChannel < ApplicationCable::Channel
-  delegate :subscription?, to: result
+  delegate :subscription?, to: :result
+
+  attr_reader :result
 
   def subscribed
     @subscription_ids = []
@@ -13,7 +15,7 @@ class GraphqlChannel < ApplicationCable::Channel
       channel: self
     }
 
-    result = RailsApiBoilerplateSchema.execute(
+    @result = RailsApiBoilerplateSchema.execute(
       query: query,
       context: context,
       variables: variables,

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Raven.configure do |config|
   config.async = ->(event) { SentryJob.perform_later(event) }
-  config.dsn = ENV.fetch('SENTRY_DSN', nil)
+  config.dsn = ENV['SENTRY_DSN']
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  if Rails.env.development?
+  if ENV.fetch('MOUNT_GRAPHIQL', 'false') == 'true'
     mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: 'graphql#execute'
   end
 


### PR DESCRIPTION
#### Description:

I set up the Heroku API to host this, and made the necessary code fixes for it to run properly. 
This PR configures CD with github actions so that everytime somebody merges (or pushes) into master, the heroku api will get synced.

Heroku URL: 

http://rails-graphql-api-boilerplate.herokuapp.com/graphiql

It has configures a postgres db, redis db, sentry for monitoring, a web dyno and a worker dyno. 

---

ALERT

**I had to load the graphiql gem to the production group as well.** 

If I did not add the gem to the production group as well I was getting this error when deploying:

```
remote:        Sprockets::FileNotFound: couldn't find file 'graphiql/rails/application.css'
```

Also because the gem on production group is needed in order to be able to then grant the frontenders access to the documentation not just locally on our computers. This change was also be needed in routes.rb later to be consistent. We needed a way to toggle ON/OFF the graphiql console for different environments (we want it in local, dev, staging but not on prod). So I added an ENV var to switch this feature on or off. 

---


Also fixed error:

```
2020-05-23T17:27:44.774427+00:00 app[web.1]: /app/app/channels/graphql_channel.rb:2:in `<class:GraphqlChannel>': undefined local variable or method `result' for GraphqlChannel:Class (NameError)
```