### PR TITLE
Add custom cop for db indexes

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -162,3 +162,8 @@ directories:
       enabled: false
     UncommunicativeVariableName:
       enabled: false
+  "rubocop":
+    UtilityFunction:
+      enabled: false
+    FeatureEnvy:
+      enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rails
+require:
+  - rubocop-rails
+  - ./rubocop/rubocop
 
 AllCops:
   Exclude:
@@ -6,6 +8,7 @@ AllCops:
     - .circleci/*
     - db/schema.rb
     - bin/bundle
+    - rubocop/**/*.rb
 
 Bundler/OrderedGems:
   Enabled: false

--- a/db/migrate/20190703155941_create_users.rb
+++ b/db/migrate/20190703155941_create_users.rb
@@ -1,4 +1,5 @@
 class CreateUsers < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
   enable_extension 'citext'
 
   def change
@@ -11,6 +12,6 @@ class CreateUsers < ActiveRecord::Migration[6.0]
       t.timestamps
     end
 
-    add_index :users, :email, unique: true
+    add_index :users, :email, unique: true, algorithm: :concurrently
   end
 end

--- a/rubocop/cop/migration/add_index.rb
+++ b/rubocop/cop/migration/add_index.rb
@@ -1,0 +1,58 @@
+require_relative '../../migration_helpers'
+
+module RuboCop
+  module Cop
+    module Migration
+      # Cop that checks if indexes are added in a concurrent manner.
+      class AddIndex < RuboCop::Cop::Cop
+        include MigrationHelpers
+
+        MSG_DDT = 'Prefer using disable_ddl_transaction! and { algorithm: :concurrently }'\
+                    ' when creating an index'.freeze
+        MSG_ALG = 'Prefer using { algorithm: :concurrently } when creating an index'.freeze
+
+        def_node_search :disable_ddl_transaction?, '(send $_ :disable_ddl_transaction!)'
+
+        def_node_matcher :indexes?, <<-MATCHER
+          (send _ {:add_index :drop_index} $...)
+        MATCHER
+
+        def on_class(node)
+          return unless in_migration?(node)
+
+          return if ddl_transaction_disabled?
+
+          @disable_ddl_transaction = disable_ddl_transaction?(node)
+          @offensive_node = node
+        end
+
+        def on_send(node)
+          return unless in_migration?(node)
+
+          indexes?(node) do |args|
+            add_offense(node, message: MSG_ALG) unless concurrently_enabled?(args.last)
+            add_offense(@offensive_node, message: MSG_DDT) unless ddl_transaction_disabled?
+          end
+        end
+
+        private
+
+        def concurrently_enabled?(last_arg)
+          last_arg.hash_type? && last_arg.each_descendant.any? do |node|
+            next unless node.sym_type?
+
+            concurrently?(node)
+          end
+        end
+
+        def ddl_transaction_disabled?
+          @disable_ddl_transaction
+        end
+
+        def concurrently?(node)
+          node.children.any? { |sym| sym == :concurrently }
+        end
+      end
+    end
+  end
+end

--- a/rubocop/migration_helpers.rb
+++ b/rubocop/migration_helpers.rb
@@ -1,0 +1,15 @@
+module RuboCop
+  # Module containing helper methods for writing migration cops.
+  module MigrationHelpers
+    # Returns true if the given node originated from the db/migrate directory.
+    def in_migration?(node)
+      dirname(node).end_with?('db/migrate')
+    end
+
+    private
+
+    def dirname(node)
+      File.dirname(node.location.expression.source_buffer.name)
+    end
+  end
+end

--- a/rubocop/rubocop.rb
+++ b/rubocop/rubocop.rb
@@ -1,0 +1,1 @@
+require_relative 'cop/migration/add_index'

--- a/spec/rubocop/cop/migration/add_index_spec.rb
+++ b/spec/rubocop/cop/migration/add_index_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+
+require_relative '../../../../rubocop/cop/migration/add_index'
+
+RSpec.describe RuboCop::Cop::Migration::AddIndex do
+  include CopHelper
+  include RuboCop::RSpec::ExpectOffense
+
+  subject(:cop) { described_class.new }
+
+  before do
+    allow(cop).to receive(:in_migration?).and_return(true)
+  end
+
+  context 'concurrently without disable_ddl_transaction!' do
+    it 'reports an offense' do
+      expect_offense(<<~RUBY)
+        class Migration
+        ^^^^^^^^^^^^^^^ Prefer using disable_ddl_transaction! and { algorithm: :concurrently } when creating an index
+          def change
+            add_index :table, :column, algorithm: :concurrently
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'not concurrently without disable_ddl_transaction!' do
+    it 'reports an offense' do
+      expect_offense(<<~RUBY)
+        class Migration
+        ^^^^^^^^^^^^^^^ Prefer using disable_ddl_transaction! and { algorithm: :concurrently } when creating an index
+          def change
+            add_index :table, :column
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using { algorithm: :concurrently } when creating an index
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'concurrently with disable_ddl_transaction!' do
+    it 'does not report an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Migration
+          disable_ddl_transaction!
+          def change
+            add_index :table, :column, algorithm: :concurrently
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'not concurrently with disable_ddl_transaction!' do
+    it 'reports an offense' do
+      expect_offense(<<~RUBY)
+        class Migration
+          disable_ddl_transaction!
+          def change
+            add_index :table, :column
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using { algorithm: :concurrently } when creating an index
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
#### Description:

Implement rubocop custom cop to defend agains non-concurrent indexes creation. This PR is based entirely on [this implementation](https://github.com/loopstudio/rails-api-boilerplate/pull/53).

---

@loopstudio/ruby-devs