### PR TITLE
Tweaked the code of the resolvers

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -110,6 +110,7 @@ detectors:
     enabled: true
     exclude:
       - Loaders::AssociationLoader#cache_key
+      - resolve
     public_methods_only: false
 
 ### Directory specific configuration

--- a/app/graphql/mutations/user_mutations/create_user_mutation.rb
+++ b/app/graphql/mutations/user_mutations/create_user_mutation.rb
@@ -7,13 +7,12 @@ module Mutations
       argument :password, String, required: true
 
       field :user, Types::CustomTypes::UserType, null: false
-      field :token, String, null: true
-
-      attr_reader :user
+      field :token, String, null: false
 
       def resolve(**attributes)
-        @user = User.create!(attributes)
+        user = User.create!(attributes)
         token = AuthToken.token(user)
+
         { user: user, token: token }
       end
     end

--- a/app/graphql/mutations/user_mutations/delete_user_mutation.rb
+++ b/app/graphql/mutations/user_mutations/delete_user_mutation.rb
@@ -1,18 +1,13 @@
 module Mutations
   module UserMutations
     class DeleteUserMutation < Mutations::BaseMutation
-      argument :id, ID, required: true
-
       field :user, Types::CustomTypes::UserType, null: false
 
-      attr_reader :user
+      def resolve
+        user = User.find(context[:current_user]&.id)
+        user.destroy!
 
-      def resolve(id:)
-        @user = User.find(id)
-
-        return { user: user } if user.destroy
-
-        raise GraphQL::ExecutionError, user.errors.messages.to_json
+        { user: user }
       end
     end
   end

--- a/app/graphql/mutations/user_mutations/sign_in_user_mutation.rb
+++ b/app/graphql/mutations/user_mutations/sign_in_user_mutation.rb
@@ -7,8 +7,6 @@ module Mutations
       field :user, Types::CustomTypes::UserType, null: true
       field :token, String, null: true
 
-      attr_reader :user
-
       def resolve(email:, password:)
         user = User.find_by(email: email)
 

--- a/app/graphql/mutations/user_mutations/update_user_mutation.rb
+++ b/app/graphql/mutations/user_mutations/update_user_mutation.rb
@@ -9,7 +9,7 @@ module Mutations
       field :user, Types::CustomTypes::UserType, null: false
 
       def resolve(**attributes)
-        user = User.find(context[:current_user].id)
+        user = User.find(context[:current_user]&.id)
         user.update!(attributes)
 
         { user: user }

--- a/app/graphql/queries/user.rb
+++ b/app/graphql/queries/user.rb
@@ -1,6 +1,6 @@
 module Queries
   class User < Queries::BaseQuery
-    type Types::CustomTypes::UserType, null: false
+    type Types::CustomTypes::UserType, null: true
 
     def resolve
       context[:current_user]

--- a/spec/requests/users/show_spec.rb
+++ b/spec/requests/users/show_spec.rb
@@ -50,16 +50,16 @@ describe 'Show current user request', type: :request do
       graphql_request(request_body)
     end
 
-    it 'returns an error message' do
+    it 'does not return an error message' do
       request
 
-      expect(errors).not_to be_nil
+      expect(errors).to be_nil
     end
 
     it 'does not return any data' do
       request
 
-      expect(json[:data]).to be_nil
+      expect(json[:data][:user]).to be_nil
     end
   end
 end


### PR DESCRIPTION
#### Description:

Adding `attr_reader :user` just so we avoid the reek warning wasn't cutting it for me so I decided to better exclude the resolvers from that validation as we aren't really using `@user` outside of the resolvers. I also check what logic seems better for when the response could be `nil` and make use of the banger on the destroy user mutation.

---

@loopstudio/ruby-devs
