### PR TITLE
Reduce Metrics/MethodLength from 24 to the default (10)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,49 +22,23 @@ AllCops:
 
 Layout/LineLength:
   Max: 100
-  AllowURI: true
-  URISchemes:
-    - http
-    - https
   Exclude:
     - config/**/*
 
 Metrics/AbcSize:
-  Max: 15
   Exclude:
     - db/migrate/*
     - app/channels/graphql_channel.rb
 
 Metrics/BlockLength:
-  CountComments: false
-  Max: 25
   Exclude:
     - config/**/*
     - spec/**/*
     - lib/tasks/auto_annotate_models.rake
 
-Metrics/BlockNesting:
-  Max: 4
-
-Metrics/ClassLength:
-  CountComments: false
-  Max: 200
-
-Metrics/CyclomaticComplexity:
-  Max: 6
 
 Metrics/MethodLength:
-  CountComments: false
   Max: 24
-
-Metrics/ModuleLength:
-  CountComments: false
-  Max: 200
-
-Metrics/ParameterLists:
-  Max: 5
-  CountKeywordArgs: true
-
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,9 +36,6 @@ Metrics/BlockLength:
     - spec/**/*
     - lib/tasks/auto_annotate_models.rake
 
-
-Metrics/MethodLength:
-  Max: 24
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
 
@@ -47,3 +44,7 @@ Style/Documentation:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/NumericLiterals:
+  Exclude:
+    - config/initializers/strong_migrations.rb


### PR DESCRIPTION
### Description:
* Remove unnecessary data in `.rubocop.yml` file
* Reduce Metrics/MethodLength from 24 to the default (10). This implies to modify two methods in `GraphqlChannel` class:
  - `execute`
  - `ensure_hash`