### PR TITLE
feat: Update workflow to use new 'setup Ruby' action (old was depreca…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @nbassagoda @aperezcristina @elestu @mconiglio @diebas @cindy-a @Stefano-loop
+* @aperezcristina @elestu @mconiglio @diebas @Stefano-loop @fdecono

--- a/.github/workflows/test_and_liters.yml
+++ b/.github/workflows/test_and_liters.yml
@@ -24,21 +24,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby (.ruby-version)
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.x
+        bundler-cache: true
 
     - name: Install PostgreSQL 11 client
       run: sudo apt-get -yqq install libpq-dev
-
-    - uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-          ${{ runner.os }}-
 
     - name: Build App
       env:


### PR DESCRIPTION
…ted)

> NOTE: This action is deprecated and is no longer maintained.
> Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.

@loopstudio/ruby-devs
