### PR TITLE
Remove deprecated config from the GQL schema declarations as it's now the default

### DIFF
--- a/app/graphql/rails_api_boilerplate_schema.rb
+++ b/app/graphql/rails_api_boilerplate_schema.rb
@@ -2,7 +2,6 @@ class RailsApiBoilerplateSchema < GraphQL::Schema
   disable_introspection_entry_points unless GraphqlConfig::EXPOSE_API_INSIGHTS
   use GraphQL::Subscriptions::ActionCableSubscriptions, redis: Redis.new
   use GraphQL::Batch
-  use GraphQL::Analysis::AST
   query_analyzer QueryAnalyzers::QueryComplexityAnalyzer
   query_analyzer QueryAnalyzers::QueryDepthAnalyzer
 


### PR DESCRIPTION
#### Description:

Fix this deprecation warning
> DEPRECATION WARNING: GraphQL::Analysis::AST is now the default; remove `use GraphQL::Analysis::AST` from the schema definition

---

@loopstudio/ruby-devs
